### PR TITLE
Fix lodash not found

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,7 +12,6 @@ build/**
 tsconfig.json
 vsc-extension-quickstart.md
 build.sh
-node_modules/**
 **/*.map
 **/tsconfig.json
 **/.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
     "name": "vscode-coldbox",
-    "version": "1.1.0-snapshot",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "vscode-coldbox",
-            "version": "1.1.0-snapshot",
+            "version": "1.1.0",
             "dependencies": {
-                "convert-snippets-to-vscode": "^1.0.2",
-                "lodash": "^4.17.21"
+                "lodash.endswith": "^4.2.1",
+                "lodash.has": "^4.5.2",
+                "lodash.isempty": "^4.4.0",
+                "lodash.keys": "^4.2.0",
+                "lodash.startswith": "^4.2.1"
             },
             "devDependencies": {
                 "@types/glob": "^8.1.0",
@@ -19,6 +22,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.38.1",
                 "@typescript-eslint/parser": "^5.38.1",
                 "@vscode/vsce": "^2.19.0",
+                "convert-snippets-to-vscode": "^1.0.2",
                 "eslint": "^8.24.0",
                 "eslint-plugin-jsdoc": "^39.3.6",
                 "glob": "^10.2.2",
@@ -921,6 +925,7 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
             "integrity": "sha512-8UeLcAdY7X4ZUBiuWoxqHfPGIUwJ5Vz7ujKdMUWbR0DwiBziHJbEMYzTvt7OQNtFb2NHxSxa3COicuPNgvE0XQ==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.2",
                 "collect-all": "~0.2.1"
@@ -936,6 +941,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
             "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -944,6 +950,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
             "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -970,6 +977,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
             "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
+            "dev": true,
             "dependencies": {
                 "typical": "^2.6.0"
             },
@@ -1249,6 +1257,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
             "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
+            "dev": true,
             "dependencies": {
                 "restore-cursor": "^1.0.1"
             },
@@ -1259,12 +1268,14 @@
         "node_modules/cli-width": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+            "dev": true
         },
         "node_modules/code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
             "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1273,6 +1284,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
             "integrity": "sha512-DJM6+T8WAUEDVPxvbousmxRvtGW5+Q7JazRYmELEzn+BLGlRrqQ1ENKIpfiUjveCupWgUQd4iTvrMfDo0HiVKw==",
+            "dev": true,
             "dependencies": {
                 "stream-connect": "^1.0.1",
                 "stream-via": "~0.1.0",
@@ -1286,6 +1298,7 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.9.tgz",
             "integrity": "sha512-5sGzu8rjhY4uzm4FJOVsNtcAhNiyEsZ70Lz3xv+7mXuLfU41QikE0es3nn2N0knqEKg+r4K7TMFHFmR8OFGpFA==",
+            "dev": true,
             "dependencies": {
                 "collect-all": "^1.0.4",
                 "stream-connect": "^1.0.2",
@@ -1299,6 +1312,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
             "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
+            "dev": true,
             "dependencies": {
                 "stream-connect": "^1.0.2",
                 "stream-via": "^1.0.4"
@@ -1311,6 +1325,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
             "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1334,6 +1349,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
             "integrity": "sha512-u0d19HeRqHrs8nK+dBK5yzJ1fcMKXZmhXeKOVZfjbU2PJDMavQn256E262Z1qOD5Esg32dq17cM2pYUnO1WVTw==",
+            "dev": true,
             "dependencies": {
                 "ansi-escape-sequences": "^2.2.2",
                 "array-back": "^1.0.3",
@@ -1357,6 +1373,7 @@
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
             "integrity": "sha512-qo+q+AcV8vRQCVDCoh3gNbUiVI86ywoKkIUJeNCNZBCw1qv111Dp0F3nZ2PR/92HrGsgsABuAAi7Fe/z/cj8YQ==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.2",
                 "command-line-usage": "^2",
@@ -1373,6 +1390,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
             "integrity": "sha512-xxUZrDySMWQknZRlCKXbuSCR8PUQXLbypmXPv8a1ZaxIGE5SSynjXNZzig8VTcTcXuvIVf9y563nucsRAYnCKA==",
+            "dev": true,
             "dependencies": {
                 "ansi-escape-sequences": "^2.2.2",
                 "array-back": "^1.0.3",
@@ -1413,6 +1431,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/convert-snippets-to-vscode/-/convert-snippets-to-vscode-1.0.2.tgz",
             "integrity": "sha512-mup24Y2tPfmexTwZ99fyALl2iq3FGDRAmRlCX7kmjKlfIXB/wcvppuiX1N5bL6rW+GCAuqQoCKcENoxjY5pelg==",
+            "dev": true,
             "dependencies": {
                 "command-line-args": "^2.1.6",
                 "inquirer": "^0.12.0",
@@ -1430,6 +1449,7 @@
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
             "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
             "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+            "dev": true,
             "hasInstallScript": true
         },
         "node_modules/cross-spawn": {
@@ -1511,6 +1531,7 @@
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
             "integrity": "sha512-cQ0iXSEKi3JRNhjUsLWvQ+MVPxLVqpwCd0cFsWbJxlCim2TlCo1JvN5WaPdPvSpUdEnkJ/X+mPGcq5RJ68EK8g==",
+            "dev": true,
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.12.0"
@@ -1686,6 +1707,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -2051,6 +2073,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
             "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2133,6 +2156,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
             "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.4"
             },
@@ -2144,6 +2168,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+            "dev": true,
             "dependencies": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
@@ -2180,6 +2205,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
             "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.4",
                 "test-value": "^2.1.0"
@@ -2407,6 +2433,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -2548,6 +2575,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
             "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
+            "dev": true,
             "dependencies": {
                 "ansi-escapes": "^1.1.0",
                 "ansi-regex": "^2.0.0",
@@ -2568,6 +2596,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2576,6 +2605,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
             "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+            "dev": true,
             "dependencies": {
                 "ansi-styles": "^2.2.1",
                 "escape-string-regexp": "^1.0.2",
@@ -2591,6 +2621,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
             "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+            "dev": true,
             "engines": {
                 "node": ">=0.8.0"
             }
@@ -2608,6 +2639,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+            "dev": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
             },
@@ -2837,13 +2869,39 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "node_modules/lodash.endswith": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+            "integrity": "sha512-pegckn1D2ohyUKt7OHrp7GpJVNnndjE+FpzULQ0pjQvbjdktdWGmKVth5wdSYWHzQSZA7OSGbIo0/AuwTeX1pA=="
+        },
+        "node_modules/lodash.has": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+            "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
+        },
+        "node_modules/lodash.isempty": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+        },
+        "node_modules/lodash.keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+            "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
+        },
+        "node_modules/lodash.startswith": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+            "integrity": "sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww=="
         },
         "node_modules/lru-cache": {
             "version": "6.0.0",
@@ -3100,6 +3158,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3108,6 +3167,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3115,7 +3175,8 @@
         "node_modules/object-get": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg=="
+            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
+            "dev": true
         },
         "node_modules/object-inspect": {
             "version": "1.12.3",
@@ -3130,6 +3191,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
             "integrity": "sha512-Su3j153hgK9Dgd07FTi6y6DJmJtyWxyuoWvl5VZLI6HVL9VQ81ShfT9c2l/eNIZY85axAi0t1AqFjCAATGab0g==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.2",
                 "collect-json": "^1.0.7",
@@ -3145,6 +3207,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
             "integrity": "sha512-wrsbRo7qP+2Je8x8DsK8ovCGyxe3sYfQwOraIY/09A2gFXU9DYKiTF14W4ki/01AEh56kMzAmlj9CaHGDDUBJA==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.2",
                 "typical": "^2.4.2"
@@ -3157,6 +3220,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -3165,6 +3229,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3506,6 +3571,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
             "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
+            "dev": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3515,7 +3581,8 @@
         "node_modules/readline2/node_modules/mute-stream": {
             "version": "0.0.5",
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-            "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg=="
+            "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
+            "dev": true
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -3530,6 +3597,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
             "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
+            "dev": true,
             "dependencies": {
                 "exit-hook": "^1.0.0",
                 "onetime": "^1.0.0"
@@ -3587,6 +3655,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
             "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
+            "dev": true,
             "dependencies": {
                 "once": "^1.3.0"
             }
@@ -3617,7 +3686,8 @@
         "node_modules/rx-lite": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ=="
+            "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
+            "dev": true
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
@@ -3642,7 +3712,8 @@
         "node_modules/sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "node_modules/schema-utils": {
             "version": "3.1.2",
@@ -3832,6 +3903,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
             "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.2"
             },
@@ -3843,6 +3915,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
             "integrity": "sha512-1U7icavM/2dRDSevxnJRZfKBWrnhmtdCh0zQTThwYchL2YWjbwZb2PEngEj9HKjgyJ2oDipz6TLud/AU6BAIzQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3861,6 +3934,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+            "dev": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3919,6 +3993,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
             },
@@ -4074,6 +4149,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
             "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.3",
                 "typical": "^2.6.0"
@@ -4091,7 +4167,8 @@
         "node_modules/through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
         },
         "node_modules/tmp": {
             "version": "0.2.1",
@@ -4315,7 +4392,8 @@
         "node_modules/typical": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg=="
+            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+            "dev": true
         },
         "node_modules/uc.micro": {
             "version": "1.0.6",
@@ -4482,6 +4560,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
             "integrity": "sha512-oHt3LHdyJ2xke7aFYuXXB4QBvfORPZAfwdOW5bKQhCNj2Fa+I/WBz81yle19Cs7gZvaBxoYKOuPW/mFe4X09lg==",
+            "dev": true,
             "dependencies": {
                 "array-back": "^1.0.3",
                 "typical": "^2.5.0"
@@ -4667,7 +4746,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "node_modules/xml2js": {
             "version": "0.5.0",
@@ -5418,6 +5498,7 @@
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-2.2.2.tgz",
             "integrity": "sha512-8UeLcAdY7X4ZUBiuWoxqHfPGIUwJ5Vz7ujKdMUWbR0DwiBziHJbEMYzTvt7OQNtFb2NHxSxa3COicuPNgvE0XQ==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.2",
                 "collect-all": "~0.2.1"
@@ -5426,12 +5507,14 @@
         "ansi-escapes": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-            "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw=="
+            "integrity": "sha512-wiXutNjDUlNEDWHcYH3jtZUhd3c4/VojassD8zHdHCY13xbZy2XbW+NKQwA0tWGBVzDA9qEzYwfoSsWmviidhw==",
+            "dev": true
         },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
+            "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+            "dev": true
         },
         "ansi-styles": {
             "version": "3.2.1",
@@ -5452,6 +5535,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
             "integrity": "sha512-1WxbZvrmyhkNoeYcizokbmh5oiOCIfyvGtcqbK3Ls1v1fKcquzxnQSceOx6tzq7jmai2kFLWIpGND2cLhH6TPw==",
+            "dev": true,
             "requires": {
                 "typical": "^2.6.0"
             }
@@ -5640,6 +5724,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
             "integrity": "sha512-25tABq090YNKkF6JH7lcwO0zFJTRke4Jcq9iX2nr/Sz0Cjjv4gckmwlW6Ty/aoyFd6z3ysR2hMGC2GFugmBo6A==",
+            "dev": true,
             "requires": {
                 "restore-cursor": "^1.0.1"
             }
@@ -5647,17 +5732,20 @@
         "cli-width": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
-            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
+            "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
+            "dev": true
         },
         "code-point-at": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
+            "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+            "dev": true
         },
         "collect-all": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-0.2.1.tgz",
             "integrity": "sha512-DJM6+T8WAUEDVPxvbousmxRvtGW5+Q7JazRYmELEzn+BLGlRrqQ1ENKIpfiUjveCupWgUQd4iTvrMfDo0HiVKw==",
+            "dev": true,
             "requires": {
                 "stream-connect": "^1.0.1",
                 "stream-via": "~0.1.0",
@@ -5668,6 +5756,7 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/collect-json/-/collect-json-1.0.9.tgz",
             "integrity": "sha512-5sGzu8rjhY4uzm4FJOVsNtcAhNiyEsZ70Lz3xv+7mXuLfU41QikE0es3nn2N0knqEKg+r4K7TMFHFmR8OFGpFA==",
+            "dev": true,
             "requires": {
                 "collect-all": "^1.0.4",
                 "stream-connect": "^1.0.2",
@@ -5678,6 +5767,7 @@
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/collect-all/-/collect-all-1.0.4.tgz",
                     "integrity": "sha512-RKZhRwJtJEP5FWul+gkSMEnaK6H3AGPTTWOiRimCcs+rc/OmQE3Yhy1Q7A7KsdkG3ZXVdZq68Y6ONSdvkeEcKA==",
+                    "dev": true,
                     "requires": {
                         "stream-connect": "^1.0.2",
                         "stream-via": "^1.0.4"
@@ -5686,7 +5776,8 @@
                 "stream-via": {
                     "version": "1.0.4",
                     "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-1.0.4.tgz",
-                    "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ=="
+                    "integrity": "sha512-DBp0lSvX5G9KGRDTkR/R+a29H+Wk2xItOF+MpZLLNDWbEV9tGPnqLPxHEYjmiz8xGtJHRIqmI+hCjmNzqoA4nQ==",
+                    "dev": true
                 }
             }
         },
@@ -5709,6 +5800,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/column-layout/-/column-layout-2.1.4.tgz",
             "integrity": "sha512-u0d19HeRqHrs8nK+dBK5yzJ1fcMKXZmhXeKOVZfjbU2PJDMavQn256E262Z1qOD5Esg32dq17cM2pYUnO1WVTw==",
+            "dev": true,
             "requires": {
                 "ansi-escape-sequences": "^2.2.2",
                 "array-back": "^1.0.3",
@@ -5726,6 +5818,7 @@
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-2.1.6.tgz",
             "integrity": "sha512-qo+q+AcV8vRQCVDCoh3gNbUiVI86ywoKkIUJeNCNZBCw1qv111Dp0F3nZ2PR/92HrGsgsABuAAi7Fe/z/cj8YQ==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.2",
                 "command-line-usage": "^2",
@@ -5739,6 +5832,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-2.0.5.tgz",
             "integrity": "sha512-xxUZrDySMWQknZRlCKXbuSCR8PUQXLbypmXPv8a1ZaxIGE5SSynjXNZzig8VTcTcXuvIVf9y563nucsRAYnCKA==",
+            "dev": true,
             "requires": {
                 "ansi-escape-sequences": "^2.2.2",
                 "array-back": "^1.0.3",
@@ -5770,6 +5864,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/convert-snippets-to-vscode/-/convert-snippets-to-vscode-1.0.2.tgz",
             "integrity": "sha512-mup24Y2tPfmexTwZ99fyALl2iq3FGDRAmRlCX7kmjKlfIXB/wcvppuiX1N5bL6rW+GCAuqQoCKcENoxjY5pelg==",
+            "dev": true,
             "requires": {
                 "command-line-args": "^2.1.6",
                 "inquirer": "^0.12.0",
@@ -5779,7 +5874,8 @@
         "core-js": {
             "version": "2.6.12",
             "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+            "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+            "dev": true
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -5833,7 +5929,8 @@
         "deep-extend": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-            "integrity": "sha512-cQ0iXSEKi3JRNhjUsLWvQ+MVPxLVqpwCd0cFsWbJxlCim2TlCo1JvN5WaPdPvSpUdEnkJ/X+mPGcq5RJ68EK8g=="
+            "integrity": "sha512-cQ0iXSEKi3JRNhjUsLWvQ+MVPxLVqpwCd0cFsWbJxlCim2TlCo1JvN5WaPdPvSpUdEnkJ/X+mPGcq5RJ68EK8g==",
+            "dev": true
         },
         "deep-is": {
             "version": "0.1.4",
@@ -5965,7 +6062,8 @@
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true
         },
         "eslint": {
             "version": "8.40.0",
@@ -6224,7 +6322,8 @@
         "exit-hook": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg=="
+            "integrity": "sha512-MsG3prOVw1WtLXAZbM3KiYtooKR1LvxHh3VHsVtIy0uiUu8usxgB/94DP2HxtD/661lLdB6yzQ09lGJSQr6nkg==",
+            "dev": true
         },
         "expand-template": {
             "version": "2.0.3",
@@ -6297,6 +6396,7 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.5.0.tgz",
             "integrity": "sha512-DzWPIGzTnfp3/KK1d/YPfmgLqeDju9F2DQYBL35VusgSApcA7XGqVtXfR4ETOOFEzdFJ3J7zh0Gkk011TiA4uQ==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.4"
             }
@@ -6305,6 +6405,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==",
+            "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
@@ -6332,6 +6433,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
             "integrity": "sha512-KrUnjzDCD9426YnCP56zGYy/eieTnhtK6Vn++j+JJzmlsWWwEkDnsyVF575spT6HJ6Ow9tlbT3TQTDsa+O4UWA==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.4",
                 "test-value": "^2.1.0"
@@ -6507,6 +6609,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
             "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -6600,6 +6703,7 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
             "integrity": "sha512-bOetEz5+/WpgaW4D1NYOk1aD+JCqRjqu/FwRFgnIfiP7FC/zinsrfyO1vlS3nyH/R7S0IH3BIHBu4DBIDSqiGQ==",
+            "dev": true,
             "requires": {
                 "ansi-escapes": "^1.1.0",
                 "ansi-regex": "^2.0.0",
@@ -6619,12 +6723,14 @@
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="
+                    "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+                    "dev": true
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -6636,7 +6742,8 @@
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g=="
+                    "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+                    "dev": true
                 }
             }
         },
@@ -6650,6 +6757,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
             "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+            "dev": true,
             "requires": {
                 "number-is-nan": "^1.0.0"
             }
@@ -6823,13 +6931,39 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "lodash.endswith": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.endswith/-/lodash.endswith-4.2.1.tgz",
+            "integrity": "sha512-pegckn1D2ohyUKt7OHrp7GpJVNnndjE+FpzULQ0pjQvbjdktdWGmKVth5wdSYWHzQSZA7OSGbIo0/AuwTeX1pA=="
+        },
+        "lodash.has": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+            "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g=="
+        },
+        "lodash.isempty": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+            "integrity": "sha512-oKMuF3xEeqDltrGMfDxAPGIVMSSRv8tbRSODbrs4KGsRRLEhrW8N8Rd4DRgB2+621hY8A8XwwrTVhXWpxFvMzg=="
+        },
+        "lodash.keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
+            "integrity": "sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ=="
         },
         "lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
+        },
+        "lodash.startswith": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.startswith/-/lodash.startswith-4.2.1.tgz",
+            "integrity": "sha512-XClYR1h4/fJ7H+mmCKppbiBmljN/nGs73iq2SjCT9SF4CBPoUHzLvWmH1GtZMhMBZSiRkHXfeA2RY1eIlJ75ww=="
         },
         "lru-cache": {
             "version": "6.0.0",
@@ -7035,17 +7169,20 @@
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
+            "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true
         },
         "object-get": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/object-get/-/object-get-2.1.1.tgz",
-            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg=="
+            "integrity": "sha512-7n4IpLMzGGcLEMiQKsNR7vCe+N5E9LORFrtNUVy4sO3dj9a3HedZCxEL2T7QuLhcHN1NBuBsMOKaOsAYI9IIvg==",
+            "dev": true
         },
         "object-inspect": {
             "version": "1.12.3",
@@ -7057,6 +7194,7 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/object-tools/-/object-tools-2.0.6.tgz",
             "integrity": "sha512-Su3j153hgK9Dgd07FTi6y6DJmJtyWxyuoWvl5VZLI6HVL9VQ81ShfT9c2l/eNIZY85axAi0t1AqFjCAATGab0g==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.2",
                 "collect-json": "^1.0.7",
@@ -7069,6 +7207,7 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/test-value/-/test-value-1.1.0.tgz",
                     "integrity": "sha512-wrsbRo7qP+2Je8x8DsK8ovCGyxe3sYfQwOraIY/09A2gFXU9DYKiTF14W4ki/01AEh56kMzAmlj9CaHGDDUBJA==",
+                    "dev": true,
                     "requires": {
                         "array-back": "^1.0.2",
                         "typical": "^2.4.2"
@@ -7080,6 +7219,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -7087,7 +7227,8 @@
         "onetime": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A=="
+            "integrity": "sha512-GZ+g4jayMqzCRMgB2sol7GiCLjKfS1PINkjmx8spcKce1LiVqcbQreXwqs2YAFXC6R03VIG28ZS31t8M866v6A==",
+            "dev": true
         },
         "optionator": {
             "version": "0.9.1",
@@ -7335,6 +7476,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
             "integrity": "sha512-8/td4MmwUB6PkZUbV25uKz7dfrmjYWxsW8DVfibWdlHRk/l/DfHKn4pU+dfcoGLFgWOdyGCzINRQD7jn+Bv+/g==",
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7344,7 +7486,8 @@
                 "mute-stream": {
                     "version": "0.0.5",
                     "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-                    "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg=="
+                    "integrity": "sha512-EbrziT4s8cWPmzr47eYVW3wimS4HsvlnV5ri1xw1aR6JQo/OrJX5rkl32K/QQHdxeabJETtfeaROGhd8W7uBgg==",
+                    "dev": true
                 }
             }
         },
@@ -7358,6 +7501,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
             "integrity": "sha512-reSjH4HuiFlxlaBaFCiS6O76ZGG2ygKoSlCsipKdaZuKSPx/+bt9mULkn4l0asVzbEfQQmXRg6Wp6gv6m0wElw==",
+            "dev": true,
             "requires": {
                 "exit-hook": "^1.0.0",
                 "onetime": "^1.0.0"
@@ -7398,6 +7542,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
             "integrity": "sha512-qOX+w+IxFgpUpJfkv2oGN0+ExPs68F4sZHfaRRx4dDexAQkG83atugKVEylyT5ARees3HBbfmuvnjbrd8j9Wjw==",
+            "dev": true,
             "requires": {
                 "once": "^1.3.0"
             }
@@ -7414,7 +7559,8 @@
         "rx-lite": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-            "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ=="
+            "integrity": "sha512-1I1+G2gteLB8Tkt8YI1sJvSIfa0lWuRtC8GjvtyPBcLSF5jBCCJJqKrpER5JU5r6Bhe+i9/pK3VMuUcXu0kdwQ==",
+            "dev": true
         },
         "safe-buffer": {
             "version": "5.2.1",
@@ -7425,7 +7571,8 @@
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+            "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+            "dev": true
         },
         "schema-utils": {
             "version": "3.1.2",
@@ -7556,6 +7703,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-connect/-/stream-connect-1.0.2.tgz",
             "integrity": "sha512-68Kl+79cE0RGKemKkhxTSg8+6AGrqBt+cbZAXevg2iJ6Y3zX4JhA/sZeGzLpxW9cXhmqAcE7KnJCisUmIUfnFQ==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.2"
             }
@@ -7563,7 +7711,8 @@
         "stream-via": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/stream-via/-/stream-via-0.1.1.tgz",
-            "integrity": "sha512-1U7icavM/2dRDSevxnJRZfKBWrnhmtdCh0zQTThwYchL2YWjbwZb2PEngEj9HKjgyJ2oDipz6TLud/AU6BAIzQ=="
+            "integrity": "sha512-1U7icavM/2dRDSevxnJRZfKBWrnhmtdCh0zQTThwYchL2YWjbwZb2PEngEj9HKjgyJ2oDipz6TLud/AU6BAIzQ==",
+            "dev": true
         },
         "string_decoder": {
             "version": "1.3.0",
@@ -7579,6 +7728,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
             "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+            "dev": true,
             "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7623,6 +7773,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+            "dev": true,
             "requires": {
                 "ansi-regex": "^2.0.0"
             }
@@ -7733,6 +7884,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
             "integrity": "sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.3",
                 "typical": "^2.6.0"
@@ -7747,7 +7899,8 @@
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "dev": true
         },
         "tmp": {
             "version": "0.2.1",
@@ -7905,7 +8058,8 @@
         "typical": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
-            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg=="
+            "integrity": "sha512-ofhi8kjIje6npGozTip9Fr8iecmYfEbS06i0JnIg+rh51KakryWF4+jX8lLKZVhy6N+ID45WYSFCxPOdTWCzNg==",
+            "dev": true
         },
         "uc.micro": {
             "version": "1.0.6",
@@ -8022,6 +8176,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-1.2.1.tgz",
             "integrity": "sha512-oHt3LHdyJ2xke7aFYuXXB4QBvfORPZAfwdOW5bKQhCNj2Fa+I/WBz81yle19Cs7gZvaBxoYKOuPW/mFe4X09lg==",
+            "dev": true,
             "requires": {
                 "array-back": "^1.0.3",
                 "typical": "^2.5.0"
@@ -8150,7 +8305,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true
         },
         "xml2js": {
             "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -92,8 +92,11 @@
         "sublime:convert": "bash ./build.sh"
     },
     "dependencies": {
-        "convert-snippets-to-vscode": "^1.0.2",
-        "lodash": "^4.17.21"
+        "lodash.endswith": "^4.2.1",
+        "lodash.has": "^4.5.2",
+        "lodash.isempty": "^4.4.0",
+        "lodash.keys": "^4.2.0",
+        "lodash.startswith": "^4.2.1"
     },
     "devDependencies": {
         "@types/glob": "^8.1.0",
@@ -103,6 +106,7 @@
         "@typescript-eslint/eslint-plugin": "^5.38.1",
         "@typescript-eslint/parser": "^5.38.1",
         "@vscode/vsce": "^2.19.0",
+        "convert-snippets-to-vscode": "^1.0.2",
         "eslint": "^8.24.0",
         "eslint-plugin-jsdoc": "^39.3.6",
         "glob": "^10.2.2",

--- a/src/services/CompletionFactory.ts
+++ b/src/services/CompletionFactory.ts
@@ -1,9 +1,13 @@
 import * as vscode from "vscode";
-import * as _ from "lodash";
+import has from "lodash.has";
+import keys from "lodash.keys";
+import endsWith from "lodash.endswith";
+import startsWith from "lodash.startswith";
+import isEmpty from "lodash.isempty";
 import { CompletionDataStore, CompletionInfo } from "../data/CompletionDataStore";
 
 export class CompletionFactory {
-	private static prefixes = _.keys( CompletionDataStore.completions )
+	private static prefixes = keys( CompletionDataStore.completions )
 		.filter( ( value: string ) => {
 			return value !== "all";
 		}
@@ -38,14 +42,14 @@ export class CompletionFactory {
 		line = line.trim().toLocaleLowerCase();
 
 		// If the line doesn't ends whit dot
-		if ( !_.endsWith( line, "." ) ) { return null; }
+		if ( !endsWith( line, "." ) ) { return null; }
 
 		// Get the line from the first to the latest char
 		line = line.substr( 0, line.length - 1 );
 
 		// Search lines that ends with prefixes
 		for ( const prefix of CompletionFactory.prefixes ) {
-			if ( _.endsWith( line, prefix ) ) { return prefix; }
+			if ( endsWith( line, prefix ) ) { return prefix; }
 		}
 
 		// Defaults return null
@@ -79,7 +83,7 @@ export class CompletionFactory {
 	}
 
 	private getTargetCompletions( prefix: string ): vscode.CompletionItem[] {
-		if ( !_.has( CompletionDataStore.completions, prefix ) ) { return null; }
+		if ( !has( CompletionDataStore.completions, prefix ) ) { return null; }
 
 		const result  = [];
 		const items   = CompletionDataStore.completions[ prefix ];
@@ -98,24 +102,24 @@ export class CompletionFactory {
 		filterOutPrefix?: string ): vscode.CompletionItem {
 
 		if ( typeof data === "object" ) {
-			const trigger     = _.isEmpty( prefix ) ? data.trigger : `${prefix}.${data.trigger}`;
+			const trigger     = isEmpty( prefix ) ? data.trigger : `${prefix}.${data.trigger}`;
 			const item        = new vscode.CompletionItem( trigger, vscode.CompletionItemKind.Snippet );
 			let snippetSrc  = data.snippet;
 
-			if ( !_.isEmpty( filterOutPrefix ) && _.startsWith( snippetSrc, filterOutPrefix + "." ) ) {
+			if ( !isEmpty( filterOutPrefix ) && startsWith( snippetSrc, filterOutPrefix + "." ) ) {
 				snippetSrc = snippetSrc.substring( filterOutPrefix.length + 1 );
 			}
 
 			const snippet = new vscode.SnippetString( snippetSrc );
 			item.insertText = snippet;
 
-			if ( !_.isEmpty( data.doc ) ) { item.documentation = data.doc; }
+			if ( !isEmpty( data.doc ) ) { item.documentation = data.doc; }
 
 			return item;
 		}
 
 		else if ( typeof data === "string" ) {
-			const trigger = _.isEmpty( prefix ) ? data : `${prefix}.${data}`;
+			const trigger = isEmpty( prefix ) ? data : `${prefix}.${data}`;
 			const item    = new vscode.CompletionItem( trigger, vscode.CompletionItemKind.Text );
 			return item;
 		}


### PR DESCRIPTION
Fixes https://github.com/ColdBox/vscode-coldbox/issues/20

This PR fixes that issue, and subsequently, and issue when I cannot get code completion on anything (event, prc, rc....)

Lodash is not found, because in `.vscodeignore` file there's an ignored node_modules folder, so no lodash is bundled, so not found.

If you remove that line, the extension works, but then you have a massive big extension because when package a vsix, `vsce` bundles all libraries required in package.json. That's why I moved `convert-snippets-to-vscode` to devDependencies, uninstall lodash and install lodash [per method packages](https://lodash.com/per-method-packages) to reduce the bundle size.

In my humble opinion, this extension should be [bundled whit webpack](https://code.visualstudio.com/api/working-with-extensions/bundling-extension) but literary this is my second time with VS Code extensions
